### PR TITLE
[RFC] Allow configuring storage options for keyspaces

### DIFF
--- a/cql3/statements/ks_prop_defs.hh
+++ b/cql3/statements/ks_prop_defs.hh
@@ -42,6 +42,7 @@
 #pragma once
 
 #include "cql3/statements/property_definitions.hh"
+#include "db/storage_options.hh"
 
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
@@ -64,6 +65,7 @@ class ks_prop_defs : public property_definitions {
 public:
     static constexpr auto KW_DURABLE_WRITES = "durable_writes";
     static constexpr auto KW_REPLICATION = "replication";
+    static constexpr auto KW_STORAGE = "storage";
 
     static constexpr auto REPLICATION_STRATEGY_CLASS_KEY = "class";
     static constexpr auto REPLICATION_FACTOR_KEY = "replication_factor";
@@ -73,6 +75,7 @@ public:
     void validate();
     std::map<sstring, sstring> get_replication_options() const;
     std::optional<sstring> get_replication_strategy_class() const;
+    storage_options get_storage_options() const;
     lw_shared_ptr<keyspace_metadata> as_ks_metadata(sstring ks_name, const locator::token_metadata&);
     lw_shared_ptr<keyspace_metadata> as_ks_metadata_update(lw_shared_ptr<keyspace_metadata> old, const locator::token_metadata&);
 

--- a/database.cc
+++ b/database.cc
@@ -111,9 +111,10 @@ keyspace_metadata::new_keyspace(std::string_view name,
                                 std::string_view strategy_name,
                                 locator::replication_strategy_config_options options,
                                 bool durables_writes,
-                                std::vector<schema_ptr> cf_defs)
+                                std::vector<schema_ptr> cf_defs,
+                                storage_options storage_opts)
 {
-    return ::make_lw_shared<keyspace_metadata>(name, strategy_name, options, durables_writes, cf_defs);
+    return ::make_lw_shared<keyspace_metadata>(name, strategy_name, options, durables_writes, cf_defs, user_types_metadata{}, storage_opts);
 }
 
 void keyspace_metadata::add_user_type(const user_type ut) {
@@ -1215,11 +1216,27 @@ keyspace_metadata::keyspace_metadata(std::string_view name,
              bool durable_writes,
              std::vector<schema_ptr> cf_defs,
              user_types_metadata user_types)
+    : keyspace_metadata(name,
+                        strategy_name,
+                        std::move(strategy_options),
+                        durable_writes,
+                        std::move(cf_defs),
+                        user_types_metadata{},
+                        storage_options{}) { }
+
+keyspace_metadata::keyspace_metadata(std::string_view name,
+             std::string_view strategy_name,
+             locator::replication_strategy_config_options strategy_options,
+             bool durable_writes,
+             std::vector<schema_ptr> cf_defs,
+             user_types_metadata user_types,
+             storage_options storage_opts)
     : _name{name}
     , _strategy_name{locator::abstract_replication_strategy::to_qualified_class_name(strategy_name.empty() ? "NetworkTopologyStrategy" : strategy_name)}
     , _strategy_options{std::move(strategy_options)}
     , _durable_writes{durable_writes}
     , _user_types{std::move(user_types)}
+    , _storage_options{std::move(storage_opts)}
 {
     for (auto&& s : cf_defs) {
         _cf_meta_data.emplace(s->cf_name(), s);
@@ -1229,6 +1246,36 @@ keyspace_metadata::keyspace_metadata(std::string_view name,
 void keyspace_metadata::validate(const locator::topology& topology) const {
     using namespace locator;
     abstract_replication_strategy::validate_replication_strategy(name(), strategy_name(), strategy_options(), topology);
+}
+
+storage_options::storage_type storage_options::parse_type(std::string_view str) {
+    if (str == "NATIVE") {
+        return storage_type::NATIVE;
+    }
+    if (str == "S3") {
+        return storage_type::S3;
+    }
+    throw std::runtime_error(format("Unknown storage type: {}", str));
+}
+
+sstring storage_options::print_type(storage_type type) {
+    switch (type) {
+        case storage_type::NATIVE: return "NATIVE";
+        case storage_type::S3: return "S3";
+    }
+}
+
+std::map<sstring, sstring> storage_options::to_map() const {
+    std::map<sstring, sstring> ret{{"type", print_type(type)}};
+    auto add_nonempty = [&ret] (const char* key, const sstring& str) {
+        if (!str.empty()) {
+            ret.emplace(key, str);
+        }
+    };
+    add_nonempty("bucket", bucket);
+    add_nonempty("key_id", key_id);
+    add_nonempty("endpoint", endpoint);
+    return ret;
 }
 
 void database::validate_keyspace_update(keyspace_metadata& ksm) {

--- a/database.hh
+++ b/database.hh
@@ -76,6 +76,7 @@
 #include "query_class_config.hh"
 #include "absl-flat_hash_map.hh"
 #include "utils/cross-shard-barrier.hh"
+#include "db/storage_options.hh"
 
 class cell_locker;
 class cell_locker_stats;
@@ -1074,6 +1075,7 @@ class keyspace_metadata final {
     std::unordered_map<sstring, schema_ptr> _cf_meta_data;
     bool _durable_writes;
     user_types_metadata _user_types;
+    storage_options _storage_options;
 public:
     keyspace_metadata(std::string_view name,
                  std::string_view strategy_name,
@@ -1086,12 +1088,20 @@ public:
                  bool durable_writes,
                  std::vector<schema_ptr> cf_defs,
                  user_types_metadata user_types);
+    keyspace_metadata(std::string_view name,
+                 std::string_view strategy_name,
+                 locator::replication_strategy_config_options strategy_options,
+                 bool durable_writes,
+                 std::vector<schema_ptr> cf_defs,
+                 user_types_metadata user_types,
+                 storage_options storage_opts);
     static lw_shared_ptr<keyspace_metadata>
     new_keyspace(std::string_view name,
                  std::string_view strategy_name,
                  locator::replication_strategy_config_options options,
                  bool durables_writes,
-                 std::vector<schema_ptr> cf_defs = std::vector<schema_ptr>{});
+                 std::vector<schema_ptr> cf_defs = std::vector<schema_ptr>{},
+                 storage_options storage_opts = {});
     void validate(const locator::topology&) const;
     const sstring& name() const {
         return _name;
@@ -1113,6 +1123,9 @@ public:
     }
     const user_types_metadata& user_types() const {
         return _user_types;
+    }
+    const storage_options& get_storage_options() const {
+        return _storage_options;
     }
     void add_or_update_column_family(const schema_ptr& s) {
         _cf_meta_data[s->cf_name()] = s;

--- a/db/storage_options.hh
+++ b/db/storage_options.hh
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2021-present ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+#include <map>
+#include <seastar/core/sstring.hh>
+
+struct storage_options {
+    enum class storage_type {
+        NATIVE, S3,
+    };
+
+    storage_type type;
+    sstring bucket;
+    sstring key_id;
+    sstring endpoint;
+    storage_options() = default;
+
+    std::map<sstring, sstring> to_map() const;
+
+    static storage_type parse_type(std::string_view str);
+    static sstring print_type(storage_type type);
+};

--- a/test/cql-pytest/test_keyspace.py
+++ b/test/cql-pytest/test_keyspace.py
@@ -205,6 +205,17 @@ def test_concurrent_create_and_drop_keyspace(cql, this_dc):
             cql.execute(f"DROP KEYSPACE {keyspace}")
         cql.execute(f"CREATE KEYSPACE {keyspace} {ksdef}")
 
+def test_storage_options(cql, scylla_only):
+    ksdef = "WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : '1' } " \
+            "AND STORAGE = { 'type' : 'S3', 'bucket' : '42', 'key_id' : '43', 'endpoint' : 'localhost' }"
+    with new_test_keyspace(cql, ksdef) as keyspace:
+        res = cql.execute(f"SELECT * FROM system_schema.keyspaces WHERE keyspace_name = '{keyspace}'")
+        info = res.one().storage
+        assert info['type'] == 'S3'
+        assert info['bucket'] == '42'
+        assert info['key_id'] == '43'
+        assert info['endpoint'] == 'localhost'
+
 # TODO: more tests for "WITH REPLICATION" syntax in CREATE TABLE.
 # TODO: check the "AND DURABLE_WRITES" option of CREATE TABLE.
 # TODO: confirm case insensitivity without quotes, and case sensitivity with them.


### PR DESCRIPTION
The STORAGE option is designed to hold a map of options
used for customizing storage for given keyspace.

Example:
```cql
cassandra@cqlsh> CREATE KEYSPACE ks WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 } AND STORAGE = { 'type' : 'S3', 'bucket' : '42', 'key_id' : '43', 'endpoint' : 'localhost' } ;
cassandra@cqlsh> select * from system_schema.keyspaces ;

 keyspace_name                 | durable_writes | replication                                                                         | storage
-------------------------------+----------------+-------------------------------------------------------------------------------------+-------------------------------------------------------------------------
                   system_auth |           True | {'class': 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor': '1'} |                                                      {'type': 'NATIVE'}
                 system_schema |           True |                             {'class': 'org.apache.cassandra.locator.LocalStrategy'} |                                                      {'type': 'NATIVE'}
            system_distributed |           True | {'class': 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor': '3'} |                                                      {'type': 'NATIVE'}
                        system |           True |                             {'class': 'org.apache.cassandra.locator.LocalStrategy'} |                                                      {'type': 'NATIVE'}
                            ks |           True | {'class': 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor': '1'} | {'bucket': '42', 'endpoint': 'localhost', 'key_id': '43', 'type': 'S3'}
                 system_traces |           True | {'class': 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor': '2'} |                                                      {'type': 'NATIVE'}
 system_distributed_everywhere |           True |                        {'class': 'org.apache.cassandra.locator.EverywhereStrategy'} |                                                      {'type': 'NATIVE'}

```

RFC because:
 1. the storage options are not used anywhere
 2. no tests are added yet (a cql-pytest case will be added)
 3. the commit absolutely disregards the fact that `system_schema.keyspaces` just got a new column, which isn't backwrad compatible

I'd especially appreciate a suggestion for solving (3.) - should we extend `system_schema.keyspaces`, and follow with introducing a schema feature + some more complicated backward compatibility tests? One alternative is a separate table (`scylla_keyspaces`?), but I'm not sure if there's any real gain, maybe except keeping the original schema tables compatible with Cassandra.