### PR TITLE
Add a method to return a list of shared sstables co-owned by a node 

### DIFF
--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -137,6 +137,7 @@ public:
 
     future<> add_shared_sstable_owner(utils::UUID table_id, sstring sstable, gms::inet_address owner);
     future<bool> remove_shared_sstable_owner(utils::UUID table_id, sstring sstable, gms::inet_address owner);
+    future<std::vector<sstring>> shared_sstables_owned_by(gms::inet_address owner, utils::UUID table_id);
 };
 
 }

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -66,6 +66,7 @@ public:
 
 namespace db {
     class config;
+    class system_distributed_keyspace;
 }
 
 struct scheduling_groups {
@@ -163,6 +164,8 @@ public:
     virtual sharded<service::migration_manager>& migration_manager() = 0;
 
     virtual future<> refresh_client_state() = 0;
+
+    virtual sharded<db::system_distributed_keyspace>& sys_dist_ks() = 0;
 };
 
 future<> do_with_cql_env(std::function<future<>(cql_test_env&)> func, cql_test_config = {});


### PR DESCRIPTION
Also, a couple of code cleanups for CQL syntax in other shared_sstables methods.

Expose a `system_distributed_keyspace` sharded service in the `cql_test_env` to be able to write tests using `system_distributed*` keyspaces.