### PR TITLE
treewide: add LOCAL_SHARED storage type for testing purposes

### DIFF
--- a/database.cc
+++ b/database.cc
@@ -1255,6 +1255,9 @@ storage_options::storage_type storage_options::parse_type(std::string_view str) 
     if (str == "S3") {
         return storage_type::S3;
     }
+    if (str == "LOCAL_SHARED") {
+        return storage_type::LOCAL_SHARED;
+    }
     throw std::runtime_error(format("Unknown storage type: {}", str));
 }
 
@@ -1262,7 +1265,12 @@ sstring storage_options::print_type(storage_type type) {
     switch (type) {
         case storage_type::NATIVE: return "NATIVE";
         case storage_type::S3: return "S3";
+        case storage_type::LOCAL_SHARED: return "LOCAL_SHARED";
     }
+}
+
+bool storage_options::is_shared() const {
+    return type != storage_type::NATIVE;
 }
 
 std::map<sstring, sstring> storage_options::to_map() const {

--- a/db/storage_options.hh
+++ b/db/storage_options.hh
@@ -27,7 +27,7 @@
 
 struct storage_options {
     enum class storage_type {
-        NATIVE, S3,
+        NATIVE, S3, LOCAL_SHARED,
     };
 
     storage_type type = storage_type::NATIVE;
@@ -36,6 +36,7 @@ struct storage_options {
     sstring endpoint;
     storage_options() = default;
 
+    bool is_shared() const;
     std::map<sstring, sstring> to_map() const;
 
     static storage_type parse_type(std::string_view str);

--- a/distributed_loader.cc
+++ b/distributed_loader.cc
@@ -534,7 +534,7 @@ future<> distributed_loader::handle_sstables_pending_delete(sstring pending_dele
 }
 
 future<> distributed_loader::populate_column_family(distributed<database>& db, sstring sstdir, sstring ks, sstring cf) {
-    if (db.local().find_keyspace(ks).metadata()->get_storage_options().type == storage_options::storage_type::S3) {
+    if (db.local().find_keyspace(ks).metadata()->get_storage_options().is_shared()) {
         auto table_id = db.local().find_uuid(ks, cf);
         auto sstable_names = co_await db.local().get_user_sstables_manager().shared_sstables_owned_by(table_id);
         co_await process_sstable_names(db, ks, cf, boost::copy_range<std::unordered_set<sstring>>(sstable_names));

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1301,7 +1301,7 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
         size_t nr_ranges_total = 0;
 
         auto streaming_alternative = [] (keyspace& ks) {
-            return ks.metadata()->get_storage_options().type == storage_options::storage_type::S3;
+            return ks.metadata()->get_storage_options().is_shared();
         };
 
         for (auto& keyspace_name : keyspaces) {

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -887,6 +887,8 @@ void writer::init_file_writers() {
 
     data_sink out = [&] {
         switch (_sst._storage_options.type) {
+            case storage_options::storage_type::LOCAL_SHARED:
+                [[fallthrough]];
             case storage_options::storage_type::NATIVE: {
                 return make_file_data_sink(std::move(_sst._data_file), options).get0();
             }
@@ -910,6 +912,8 @@ void writer::init_file_writers() {
 
     data_sink index_out = [&] {
         switch (_sst._storage_options.type) {
+            case storage_options::storage_type::LOCAL_SHARED:
+                [[fallthrough]];
             case storage_options::storage_type::NATIVE: {
                 return make_file_data_sink(std::move(_sst._index_file), options).get0();
             }

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -406,12 +406,10 @@ public:
         return dirpath.filename().string() == pending_delete_dir_basename().c_str();
     }
 
-    const sstring& get_dir() const {
-        return _dir;
-    }
+    const sstring& get_dir() const;
 
     const sstring get_temp_dir() const {
-        return temp_sst_dir(_dir, _generation);
+        return temp_sst_dir(get_dir(), _generation);
     }
 
     bool requires_view_building() const;


### PR DESCRIPTION
The LOCAL_SHARED type uses a shared resource which is simply a local
filesystem directory. The assumption is that this mode is only used
in tests, which run multiple Scylla nodes on a single machine.
These machines have access to the local filesystem, so the 'bucket'
parameter for storage is used to indicate the local path in which
all the sstables from shared sstables are stored.

Tested manually by spinning a 3-node cluster, creating a keyspace
with local_shared storage and rf=3, and then adding some data
to the table and flushing the nodes one by one. Here's the final
result - note the top bits of each generation, which translate
to unique node ids:

```
[sarna@localhost shared]$ ls -l
total 200
-rw-r--r--. 1 sarna sarna   66 Jan 18 12:09 md-1000001-big-CompressionInfo.db
-rw-r--r--. 1 sarna sarna   43 Jan 18 12:09 md-1000001-big-Data.db
-rw-r--r--. 1 sarna sarna   10 Jan 18 12:09 md-1000001-big-Digest.crc32
-rw-r--r--. 1 sarna sarna   16 Jan 18 12:09 md-1000001-big-Filter.db
-rw-r--r--. 1 sarna sarna   16 Jan 18 12:09 md-1000001-big-Index.db
-rw-r--r--. 1 sarna sarna  206 Jan 18 12:09 md-1000001-big-Scylla.db
-rw-r--r--. 1 sarna sarna 4564 Jan 18 12:09 md-1000001-big-Statistics.db
-rw-r--r--. 1 sarna sarna   56 Jan 18 12:09 md-1000001-big-Summary.db
-rw-r--r--. 1 sarna sarna  102 Jan 18 12:09 md-1000001-big-TOC.txt
-rw-r--r--. 1 sarna sarna   66 Jan 18 12:09 md-1000002-big-CompressionInfo.db
-rw-r--r--. 1 sarna sarna   43 Jan 18 12:09 md-1000002-big-Data.db
-rw-r--r--. 1 sarna sarna   10 Jan 18 12:09 md-1000002-big-Digest.crc32
-rw-r--r--. 1 sarna sarna   16 Jan 18 12:09 md-1000002-big-Filter.db
-rw-r--r--. 1 sarna sarna   16 Jan 18 12:09 md-1000002-big-Index.db
-rw-r--r--. 1 sarna sarna  206 Jan 18 12:09 md-1000002-big-Scylla.db
-rw-r--r--. 1 sarna sarna 4564 Jan 18 12:09 md-1000002-big-Statistics.db
-rw-r--r--. 1 sarna sarna   56 Jan 18 12:09 md-1000002-big-Summary.db
-rw-r--r--. 1 sarna sarna  102 Jan 18 12:09 md-1000002-big-TOC.txt
-rw-r--r--. 1 sarna sarna   66 Jan 18 12:08 md-1000003-big-CompressionInfo.db
-rw-r--r--. 1 sarna sarna   47 Jan 18 12:08 md-1000003-big-Data.db
-rw-r--r--. 1 sarna sarna   10 Jan 18 12:08 md-1000003-big-Digest.crc32
-rw-r--r--. 1 sarna sarna   16 Jan 18 12:08 md-1000003-big-Filter.db
-rw-r--r--. 1 sarna sarna   16 Jan 18 12:08 md-1000003-big-Index.db
-rw-r--r--. 1 sarna sarna  207 Jan 18 12:08 md-1000003-big-Scylla.db
-rw-r--r--. 1 sarna sarna 4542 Jan 18 12:08 md-1000003-big-Statistics.db
-rw-r--r--. 1 sarna sarna   56 Jan 18 12:08 md-1000003-big-Summary.db
-rw-r--r--. 1 sarna sarna  102 Jan 18 12:08 md-1000003-big-TOC.txt
-rw-r--r--. 1 sarna sarna   66 Jan 18 12:09 md-2000003-big-CompressionInfo.db
-rw-r--r--. 1 sarna sarna   43 Jan 18 12:09 md-2000003-big-Data.db
-rw-r--r--. 1 sarna sarna   10 Jan 18 12:09 md-2000003-big-Digest.crc32
-rw-r--r--. 1 sarna sarna   16 Jan 18 12:09 md-2000003-big-Filter.db
-rw-r--r--. 1 sarna sarna   16 Jan 18 12:09 md-2000003-big-Index.db
-rw-r--r--. 1 sarna sarna  206 Jan 18 12:09 md-2000003-big-Scylla.db
-rw-r--r--. 1 sarna sarna 4564 Jan 18 12:09 md-2000003-big-Statistics.db
-rw-r--r--. 1 sarna sarna   56 Jan 18 12:09 md-2000003-big-Summary.db
-rw-r--r--. 1 sarna sarna  102 Jan 18 12:09 md-2000003-big-TOC.txt
-rw-r--r--. 1 sarna sarna   66 Jan 18 12:09 md-3000003-big-CompressionInfo.db
-rw-r--r--. 1 sarna sarna   43 Jan 18 12:09 md-3000003-big-Data.db
-rw-r--r--. 1 sarna sarna   10 Jan 18 12:09 md-3000003-big-Digest.crc32
-rw-r--r--. 1 sarna sarna  336 Jan 18 12:09 md-3000003-big-Filter.db
-rw-r--r--. 1 sarna sarna   16 Jan 18 12:09 md-3000003-big-Index.db
-rw-r--r--. 1 sarna sarna  208 Jan 18 12:09 md-3000003-big-Scylla.db
-rw-r--r--. 1 sarna sarna 4552 Jan 18 12:09 md-3000003-big-Statistics.db
-rw-r--r--. 1 sarna sarna   56 Jan 18 12:09 md-3000003-big-Summary.db
-rw-r--r--. 1 sarna sarna  102 Jan 18 12:09 md-3000003-big-TOC.txt
drwxr-xr-x. 2 sarna sarna   40 Jan 18 12:09 pending_delete
```